### PR TITLE
Candidates will retry requesting a vote from a peer.

### DIFF
--- a/peer.go
+++ b/peer.go
@@ -1,0 +1,5 @@
+package graft
+
+type Peer interface {
+	ReceiveRequestVote(RequestVoteMessage) VoteResponseMessage
+}

--- a/peer.go
+++ b/peer.go
@@ -1,5 +1,5 @@
 package graft
 
 type Peer interface {
-	ReceiveRequestVote(RequestVoteMessage) VoteResponseMessage
+	ReceiveRequestVote(RequestVoteMessage) (VoteResponseMessage, error)
 }

--- a/server.go
+++ b/server.go
@@ -27,7 +27,7 @@ type Server struct {
 	VotedFor      string
 	VotesGranted  int
 	State         string
-	Peers         []*Server
+	Peers         []Peer
 	ElectionTimer Timable
 	StateMachine  Commiter
 	CommitIndex   int
@@ -41,12 +41,12 @@ func New() *Server {
 		VotedFor:      "",
 		VotesGranted:  0,
 		State:         Follower,
-		Peers:         []*Server{},
+		Peers:         []Peer{},
 		ElectionTimer: NullTimer{},
 	}
 }
 
-func (server *Server) AddPeer(peer *Server) {
+func (server *Server) AddPeer(peer Peer) {
 	server.Peers = append(server.Peers, peer)
 }
 


### PR DESCRIPTION
We should build in some kind of sleep or timeout or I think this code could result in many TCP connections being made until the election timeout hits.
